### PR TITLE
Check if PowerShell versoin is 7.0.0

### DIFF
--- a/IntuneToolkit.log
+++ b/IntuneToolkit.log
@@ -1,0 +1,11 @@
+<![LOG[Successfully loaded required assemblies]LOG]!><time=\22:58:45.574-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>
+<![LOG[Starting Show-Window]LOG]!><time=\22:58:45.802-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>
+<![LOG[Loading XAML file from .\XML\Main.xaml]LOG]!><time=\22:58:45.804-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>
+<![LOG[Successfully loaded XAML file]LOG]!><time=\22:58:45.908-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>
+<![LOG[Checking for latest version at https://api.github.com/repos/MG-Cloudflow/Intune-Toolkit/releases/latest]LOG]!><time=\22:58:46.743-04:00\ date=\09-24-2024\ component=\Check-LatestVersion\ context=\\ type=\1\ thread=\17\ file=\CheckVersion.ps1\>
+<![LOG[You are running the latest version (v0.2.2-alpha)]LOG]!><time=\22:58:47.222-04:00\ date=\09-24-2024\ component=\Check-LatestVersion\ context=\\ type=\1\ thread=\17\ file=\CheckVersion.ps1\>
+<![LOG[Successfully imported external scripts]LOG]!><time=\22:58:47.225-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>
+<![LOG[Starting connection to Microsoft Graph]LOG]!><time=\22:58:52.950-04:00\ date=\09-24-2024\ component=\Connect-Button\ context=\\ type=\1\ thread=\17\ file=\ConnectButton.ps1\>
+<![LOG[Successfully connected to Microsoft Graph]LOG]!><time=\22:59:00.545-04:00\ date=\09-24-2024\ component=\Connect-Button\ context=\\ type=\1\ thread=\17\ file=\ConnectButton.ps1\>
+<![LOG[Failed to connect to Microsoft Graph. Please try again. Error: Authentication needed. Please call Connect-MgGraph.]LOG]!><time=\22:59:01.991-04:00\ date=\09-24-2024\ component=\Connect-Button\ context=\\ type=\1\ thread=\17\ file=\ConnectButton.ps1\>
+<![LOG[Displayed the window successfully]LOG]!><time=\22:59:04.308-04:00\ date=\09-24-2024\ component=\Main-IntuneToolkit\ context=\\ type=\1\ thread=\17\ file=\Main.ps1\>

--- a/Main.ps1
+++ b/Main.ps1
@@ -64,6 +64,22 @@ if (-not (Get-Module -ListAvailable -Name Microsoft.Graph)) {
     exit 1
 }
 
+# Check if PowerShell versoin is 7.0.0 based on requirements from https://github.com/MG-Cloudflow/Intune-Toolkit by Thiago Beier https://x.com/thiagobeier https://github.com/thiagogbeier
+$PScurrentVersion = $PSVersionTable.PSVersion
+$PSrequiredVersion = [Version]"7.0.0"
+
+# Check if the current version is less than the required version
+if ($PScurrentVersion -lt $PSrequiredVersion) {
+    $errorMessage = "You are running PowerShell version $PScurrentVersion. Please upgrade to PowerShell 7 or higher."
+	[System.Windows.Forms.MessageBox]::Show($errorMessage, "PowerShell Version outdated", [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+	Write-IntuneToolkitLog $errorMessage
+	exit 1
+} else {
+	#$errorMessage = "You are running PowerShell version $currentVersion. All good!"
+	Write-IntuneToolkitLog $errorMessage
+}
+
+
 # Function to display the main window
 function Show-Window {
     Write-IntuneToolkitLog "Starting Show-Window"


### PR DESCRIPTION
Check if PowerShell versoin is 7.0.0 based on requirements from https://github.com/MG-Cloudflow/Intune-Toolkit
Avoids being called from Powershell 5.x (PowerShell 2.0/ISE) that fails 
Add errormessage where required 
**PLEASE IGNORE ** Create IntuneToolkit.log file to be committed or remove it from repo