### PR TITLE
Fix settings catalog comparison missing sub-settings of enabled parents

### DIFF
--- a/Scripts/Functions.ps1
+++ b/Scripts/Functions.ps1
@@ -1084,11 +1084,16 @@ function Build-CatalogDictionary {
 #--------------------------------------------------------------------------------
 function Maybe-Shorten {
     param (
-        [Parameter(Mandatory=$true)]
-        [string]$raw,
-        [Parameter(Mandatory=$true)]
-        [string]$friendly
+        [Parameter(Mandatory=$false)]
+        [AllowEmptyString()]
+        [string]$raw = "",
+        [Parameter(Mandatory=$false)]
+        [AllowEmptyString()]
+        [string]$friendly = ""
     )
+    # Fall back to the raw value when no friendly value could be resolved
+    # (some catalog entries have an empty displayName and name).
+    if ([string]::IsNullOrWhiteSpace($friendly)) { $friendly = $raw }
     # Remove any newlines and trim the friendly string.
     $friendly = ($friendly -replace "[\r\n]+", " ").Trim()
     if (($friendly.ToLower() -eq $raw.ToLower() -and $friendly.Length -gt 200) -or ($friendly -match '<\?xml')) {
@@ -1106,8 +1111,10 @@ function Find-CatalogEntry {
         [Parameter(Mandatory=$true)]
         [hashtable]$CatalogDictionary,
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [string]$Key
     )
+    if ([string]::IsNullOrWhiteSpace($Key)) { return $null }
     $lookupKey = $Key.ToLower()
     if ($CatalogDictionary.ContainsKey($lookupKey)) {
         #Write-IntuneToolkitLog "Find-CatalogEntry: Found matching entry for key '$Key'" -component "CatalogLookup" -file "SecurityBaselineAnalysisButton.ps1"
@@ -1127,15 +1134,17 @@ function Get-SettingDisplayValue {
         [hashtable]$CatalogDictionary
     )
     #Write-IntuneToolkitLog "Get-SettingDisplayValue: Looking up display value for '$settingValueId'" -component "CatalogLookup" -file "SecurityBaselineAnalysisButton.ps1"
+    # Always returns a non-empty string: falls back to the input ID when the catalog
+    # entry has no usable displayName/name (some ADMX child options ship empty values).
+    if ([string]::IsNullOrWhiteSpace($settingValueId)) { return $settingValueId }
     $entry = Find-CatalogEntry -CatalogDictionary $CatalogDictionary -Key $settingValueId
     if ($entry) {
-        if ($entry.PSObject.Properties["displayName"] -and $entry.displayName -ne "") {
-            if ($entry.displayName -eq "Top Level Setting Group Collection") {
-                return $entry.name
-            }
+        if ($entry.PSObject.Properties["displayName"] -and -not [string]::IsNullOrWhiteSpace($entry.displayName) -and $entry.displayName -ne "Top Level Setting Group Collection") {
             return $entry.displayName
         }
-        return $entry.name
+        if (-not [string]::IsNullOrWhiteSpace($entry.name)) {
+            return $entry.name
+        }
     }
     return $settingValueId
 }
@@ -1150,15 +1159,20 @@ function Get-SettingDescription {
         [hashtable]$CatalogDictionary
     )
     #Write-IntuneToolkitLog "Get-SettingDescription: Looking up description for '$settingId'" -component "CatalogLookup" -file "SecurityBaselineAnalysisButton.ps1"
+    # Always returns a non-empty string: falls back to the input ID when the catalog
+    # entry has no usable description/displayName/name.
+    if ([string]::IsNullOrWhiteSpace($settingId)) { return $settingId }
     $entry = Find-CatalogEntry -CatalogDictionary $CatalogDictionary -Key $settingId
     if ($entry) {
-        if ($entry.PSObject.Properties["description"] -and $entry.description -ne "") {
+        if ($entry.PSObject.Properties["description"] -and -not [string]::IsNullOrWhiteSpace($entry.description)) {
             return ($entry.description -replace "[\r\n]+", " ").Trim()
         }
-        elseif ($entry.PSObject.Properties["displayName"] -and $entry.displayName -ne "") {
+        if ($entry.PSObject.Properties["displayName"] -and -not [string]::IsNullOrWhiteSpace($entry.displayName)) {
             return $entry.displayName
         }
-        return $entry.name
+        if (-not [string]::IsNullOrWhiteSpace($entry.name)) {
+            return $entry.name
+        }
     }
     return $settingId
 }

--- a/Scripts/Functions.ps1
+++ b/Scripts/Functions.ps1
@@ -1090,8 +1090,8 @@ function Maybe-Shorten {
         [string]$friendly
     )
     # Remove any newlines and trim the friendly string.
-    $friendy = ($friendy -replace "[\r\n]+", " ").Trim()
-    if ($friendly.ToLower() -eq $raw.ToLower() -and $friendly.Length -gt 200 -or $friendly -contains "<?xml") {
+    $friendly = ($friendly -replace "[\r\n]+", " ").Trim()
+    if (($friendly.ToLower() -eq $raw.ToLower() -and $friendly.Length -gt 200) -or ($friendly -match '<\?xml')) {
          return "Cannot display the value in report too Long"
     }
     return $friendly
@@ -1188,36 +1188,155 @@ function Convert-CompositeToDisplay {
 #region Flattening Functions
 
 #--------------------------------------------------------------------------------
-# Function: Flatten-GroupSetting
-# This function flattens group-based baseline settings by processing each child setting individually.
+# Function: Get-SettingRawValue
+# Converts a Graph setting value object into its raw string value. Only a missing
+# value maps to "Not Defined"; falsy values such as integer 0 are kept as-is.
 #--------------------------------------------------------------------------------
-function Flatten-GroupSetting {
+function Get-SettingRawValue {
     param (
-        [string]$ParentId,
-        [array]$Children,
-        [string]$BaselinePolicy
+        $ValueObject
+    )
+    if ($null -eq $ValueObject -or $null -eq $ValueObject.value -or "$($ValueObject.value)" -eq "") {
+        return "Not Defined"
+    }
+    return "$($ValueObject.value)"
+}
+
+#--------------------------------------------------------------------------------
+# Function: Flatten-SettingInstance
+# Recursively flattens a configuration setting instance into records of
+# {Composite, SettingDefinitionId, Value}. Handles all Graph instance shapes:
+#   - choiceSettingValue (and its children, e.g. sub-settings of an "Enabled" choice)
+#   - choiceSettingCollectionValue (each entry's value and children)
+#   - simpleSettingValue
+#   - simpleSettingCollectionValue (values joined with "; ")
+#   - groupSettingCollectionValue (children of each group instance, any depth)
+# Composite paths chain setting definition IDs with "\" (Parent\Child\...).
+#--------------------------------------------------------------------------------
+function Flatten-SettingInstance {
+    param (
+        [Parameter(Mandatory=$true)]
+        $Instance,
+        [string]$ParentPath = ""
     )
     $results = @()
-    foreach ($child in $Children) {
-        # Determine the expected value based on the type of setting value.
-        if ($child.choiceSettingValue -and $child.choiceSettingValue.value) {
-            $expected = "$($child.choiceSettingValue.value)"
-        }
-        elseif ($child.simpleSettingValue -and $child.simpleSettingValue.value) {
-            $expected = "$($child.simpleSettingValue.value)"
-        }
-        else {
-            $expected = "Not Defined"
-        }
-        # Build a composite description combining parent and child IDs.
-        $composite = "$ParentId\$($child.settingDefinitionId)"
-        Write-IntuneToolkitLog "Flattened baseline child: Composite='$composite', Expected='$expected'" -component "BaselineFlatten" -file "SecurityBaselineAnalysisButton.ps1"
-        # Create a custom object for the flattened baseline setting.
+    if ($null -eq $Instance -or -not $Instance.settingDefinitionId) { return $results }
+    $id = "$($Instance.settingDefinitionId)"
+    $path = if ($ParentPath) { "$ParentPath\$id" } else { $id }
+
+    if ($Instance.choiceSettingValue) {
+        # Choice setting: emit the selected option, then flatten any child settings
+        # exposed by that option (e.g. sub-settings of an enabled parent).
         $results += [PSCustomObject]@{
-            BaselinePolicy       = $BaselinePolicy
-            CompositeDescription = $composite
-            BaselineId           = $child.settingDefinitionId
-            ExpectedValue        = $expected
+            Composite           = $path
+            SettingDefinitionId = $id
+            Value               = (Get-SettingRawValue -ValueObject $Instance.choiceSettingValue)
+        }
+        foreach ($child in @($Instance.choiceSettingValue.children)) {
+            if ($null -ne $child) {
+                $results += Flatten-SettingInstance -Instance $child -ParentPath $path
+            }
+        }
+    }
+    elseif ($Instance.simpleSettingValue) {
+        $results += [PSCustomObject]@{
+            Composite           = $path
+            SettingDefinitionId = $id
+            Value               = (Get-SettingRawValue -ValueObject $Instance.simpleSettingValue)
+        }
+    }
+    elseif ($Instance.groupSettingCollectionValue) {
+        # Group container: flatten the children of every group instance. Additionally emit
+        # one record per instance whose value is a canonical fingerprint of that instance's
+        # child values: compared as a multiset across instances, this preserves the pairing
+        # of sibling values within an instance (catching cross-instance value swaps that
+        # per-child multisets cannot), while staying insensitive to instance order.
+        foreach ($group in @($Instance.groupSettingCollectionValue)) {
+            $childRecords = @()
+            foreach ($child in @($group.children)) {
+                if ($null -ne $child) {
+                    $childRecords += Flatten-SettingInstance -Instance $child -ParentPath $path
+                }
+            }
+            if (@($childRecords).Count -gt 0) {
+                # Escape '\' and '|' in values so a value containing the join separator
+                # cannot make two structurally different instances produce equal fingerprints.
+                $fingerprint = ((@($childRecords) | ForEach-Object { "$($_.SettingDefinitionId)=$("$($_.Value)" -replace '\\','\\' -replace '\|','\|')" } | Sort-Object) -join " | ")
+                $results += [PSCustomObject]@{
+                    Composite           = $path
+                    SettingDefinitionId = $id
+                    Value               = $fingerprint
+                }
+                $results += $childRecords
+            }
+        }
+    }
+    elseif ($Instance.groupSettingValue) {
+        # Singular group instance: no value of its own; flatten its children.
+        foreach ($child in @($Instance.groupSettingValue.children)) {
+            if ($null -ne $child) {
+                $results += Flatten-SettingInstance -Instance $child -ParentPath $path
+            }
+        }
+    }
+    elseif ($Instance.simpleSettingCollectionValue) {
+        # One record per collection entry: the multiset comparison then treats the
+        # collection as an unordered set, and values containing '; ' stay unambiguous.
+        $emitted = $false
+        foreach ($v in @($Instance.simpleSettingCollectionValue)) {
+            if ($null -ne $v -and $null -ne $v.value -and "$($v.value)" -ne "") {
+                $results += [PSCustomObject]@{
+                    Composite           = $path
+                    SettingDefinitionId = $id
+                    Value               = "$($v.value)"
+                }
+                $emitted = $true
+            }
+        }
+        if (-not $emitted) {
+            $results += [PSCustomObject]@{
+                Composite           = $path
+                SettingDefinitionId = $id
+                Value               = "Not Defined"
+            }
+        }
+    }
+    elseif ($Instance.choiceSettingCollectionValue) {
+        # One record per selected option (unordered via the multiset comparison), then
+        # any children of the selected options.
+        $emitted = $false
+        $childResults = @()
+        foreach ($cv in @($Instance.choiceSettingCollectionValue)) {
+            if ($null -eq $cv) { continue }
+            if ($null -ne $cv.value -and "$($cv.value)" -ne "") {
+                $results += [PSCustomObject]@{
+                    Composite           = $path
+                    SettingDefinitionId = $id
+                    Value               = "$($cv.value)"
+                }
+                $emitted = $true
+            }
+            foreach ($child in @($cv.children)) {
+                if ($null -ne $child) {
+                    $childResults += Flatten-SettingInstance -Instance $child -ParentPath $path
+                }
+            }
+        }
+        if (-not $emitted) {
+            $results += [PSCustomObject]@{
+                Composite           = $path
+                SettingDefinitionId = $id
+                Value               = "Not Defined"
+            }
+        }
+        $results += $childResults
+    }
+    else {
+        # Unknown or empty instance shape: keep the setting visible with no value.
+        $results += [PSCustomObject]@{
+            Composite           = $path
+            SettingDefinitionId = $id
+            Value               = "Not Defined"
         }
     }
     return $results
@@ -1225,7 +1344,8 @@ function Flatten-GroupSetting {
 
 #--------------------------------------------------------------------------------
 # Function: Flatten-BaselineSettings
-# This function flattens baseline settings by processing each entry and handling group-based settings.
+# This function flattens baseline settings by recursively processing each entry,
+# including sub-settings nested under enabled choices and group collections.
 #--------------------------------------------------------------------------------
 function Flatten-BaselineSettings {
     param (
@@ -1246,28 +1366,14 @@ function Flatten-BaselineSettings {
             }
             continue
         }
-        # Check if the settingInstance is a group container.
-        if ($bs.settingInstance.'@odata.type' -eq "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance") {
-            Write-IntuneToolkitLog "Processing group container for baseline policy '$bp', ParentID: $($bs.settingInstance.settingDefinitionId)" -component "BaselineFlatten" -file "SecurityBaselineAnalysisButton.ps1"
-            $flat += Flatten-GroupSetting -ParentId $bs.settingInstance.settingDefinitionId -Children ($bs.settingInstance.groupSettingCollectionValue.children) -BaselinePolicy $bp
-        }
-        else {
-            # Process a single (non-group) baseline setting.
-            $baselineId = $bs.settingInstance.settingDefinitionId
-            if ($bs.settingInstance.choiceSettingValue -and $bs.settingInstance.choiceSettingValue.value) {
-                $expected = "$($bs.settingInstance.choiceSettingValue.value)"
-            }
-            elseif ($bs.settingInstance.simpleSettingValue -and $bs.settingInstance.simpleSettingValue.value) {
-                $expected = "$($bs.settingInstance.simpleSettingValue.value)"
-            }
-            else {
-                $expected = "Not Defined"
-            }
+        $records = @(Flatten-SettingInstance -Instance $bs.settingInstance)
+        Write-IntuneToolkitLog "Flattened baseline setting '$($bs.settingInstance.settingDefinitionId)' for policy '$bp' into $($records.Count) record(s)" -component "BaselineFlatten" -file "SecurityBaselineAnalysisButton.ps1"
+        foreach ($rec in $records) {
             $flat += [PSCustomObject]@{
                 BaselinePolicy       = $bp
-                CompositeDescription = $baselineId
-                BaselineId           = $baselineId
-                ExpectedValue        = $expected
+                CompositeDescription = $rec.Composite
+                BaselineId           = $rec.SettingDefinitionId
+                ExpectedValue        = $rec.Value
             }
         }
     }
@@ -1276,7 +1382,9 @@ function Flatten-BaselineSettings {
 
 #--------------------------------------------------------------------------------
 # Function: Flatten-PolicySettings
-# This function flattens policy settings retrieved from the Graph API, handling both single and group-based settings.
+# This function flattens policy settings retrieved from the Graph API by recursively
+# processing each entry, including sub-settings nested under enabled choices and
+# group collections.
 #--------------------------------------------------------------------------------
 function Flatten-PolicySettings {
     param (
@@ -1285,65 +1393,126 @@ function Flatten-PolicySettings {
     $flat = @()
     foreach ($entry in $MergedPolicy) {
         $bp = $entry.PolicyName
+        $policyId = if ($entry.PSObject.Properties["PolicyId"]) { $entry.PolicyId } else { $null }
         $ps = $entry.Setting
         # Validate that the settingInstance exists and contains a settingDefinitionId.
         if (-not $ps.settingInstance -or -not $ps.settingInstance.settingDefinitionId) {
             Write-IntuneToolkitLog "Policy entry for '$bp' missing settingInstance or settingDefinitionId." -component "PolicyFlatten" -file "SecurityBaselineAnalysisButton.ps1"
             $flat += [PSCustomObject]@{
                 PolicyName           = $bp
+                PolicyId             = $policyId
                 CompositeDescription = "(No settingInstance)"
                 PolicySettingId      = ""
                 ActualValue          = "Not Defined"
             }
             continue
         }
-        # If the policy setting is a group container, process each child setting.
-        if ($ps.settingInstance.'@odata.type' -eq "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance") {
-            Write-IntuneToolkitLog "Processing group container for policy '$bp', ParentID: $($ps.settingInstance.settingDefinitionId)" -component "PolicyFlatten" -file "SecurityBaselineAnalysisButton.ps1"
-            foreach ($group in $ps.settingInstance.groupSettingCollectionValue) {
-                foreach ($child in $group.children) {
-                    if ($child.choiceSettingValue -and $child.choiceSettingValue.value) {
-                        $actual = "$($child.choiceSettingValue.value)"
-                    }
-                    elseif ($child.simpleSettingValue -and $child.simpleSettingValue.value) {
-                        $actual = "$($child.simpleSettingValue.value)"
-                    }
-                    else {
-                        $actual = "Not Defined"
-                    }
-                    # Build a composite description for the child setting.
-                    $composite = "$($ps.settingInstance.settingDefinitionId)\$($child.settingDefinitionId)"
-                    Write-IntuneToolkitLog "Flattened policy child: Composite='$composite', Actual='$actual'" -component "PolicyFlatten" -file "SecurityBaselineAnalysisButton.ps1"
-                    $flat += [PSCustomObject]@{
-                        PolicyName           = $bp
-                        CompositeDescription = $composite
-                        PolicySettingId      = $child.settingDefinitionId
-                        ActualValue          = $actual
-                    }
-                }
-            }
-        }
-        else {
-            # Process a single (non-group) policy setting.
-            $policyId = $ps.settingInstance.settingDefinitionId
-            if ($ps.settingInstance.choiceSettingValue -and $ps.settingInstance.choiceSettingValue.value) {
-                $actual = "$($ps.settingInstance.choiceSettingValue.value)"
-            }
-            elseif ($ps.settingInstance.simpleSettingValue -and $ps.settingInstance.simpleSettingValue.value) {
-                $actual = "$($ps.settingInstance.simpleSettingValue.value)"
-            }
-            else {
-                $actual = "Not Defined"
-            }
+        $records = @(Flatten-SettingInstance -Instance $ps.settingInstance)
+        Write-IntuneToolkitLog "Flattened policy setting '$($ps.settingInstance.settingDefinitionId)' for policy '$bp' into $($records.Count) record(s)" -component "PolicyFlatten" -file "SecurityBaselineAnalysisButton.ps1"
+        foreach ($rec in $records) {
             $flat += [PSCustomObject]@{
                 PolicyName           = $bp
-                CompositeDescription = $policyId
-                PolicySettingId      = $policyId
-                ActualValue          = $actual
+                PolicyId             = $policyId
+                CompositeDescription = $rec.Composite
+                PolicySettingId      = $rec.SettingDefinitionId
+                ActualValue          = $rec.Value
             }
         }
     }
     return $flat
+}
+
+#--------------------------------------------------------------------------------
+# Function: Build-BaselineComparison
+# Compares flattened baseline settings against flattened policy settings.
+# Values are aggregated per setting definition ID (a setting can occur multiple
+# times, e.g. one per group collection instance) and compared as multisets per
+# policy, so repeated instances with different values do not produce false
+# "Differs" results. Note the comparison is count-sensitive by design: a policy
+# configuring MORE instances of a setting than the baseline (even with identical
+# values) is reported as "Differs". Callers must deduplicate their inputs (same
+# policy or same baseline merged twice inflates the multisets and skews results).
+# Returns one record per baseline policy + setting ID with:
+#   BaselinePolicy, CompositeDescription, BaselineId, ExpectedValues (array),
+#   PolicyMatches (array of {PolicyName, ActualValues}), Comparison
+#   ('Matches' | 'Differs' | 'Missing').
+#--------------------------------------------------------------------------------
+function Build-BaselineComparison {
+    param (
+        [array]$FlattenedBaseline,
+        [array]$FlattenedPolicy
+    )
+    # Index policy values: setting id -> policy -> list of actual values.
+    $policyIndex = @{}
+    foreach ($p in $FlattenedPolicy) {
+        $id = "$($p.PolicySettingId)"
+        if (-not $id) { continue }
+        $idKey = $id.ToLower()
+        if (-not $policyIndex.ContainsKey($idKey)) { $policyIndex[$idKey] = [ordered]@{} }
+        $polKey = if ($p.PolicyId) { "$($p.PolicyId)" } else { "$($p.PolicyName)" }
+        if (-not $policyIndex[$idKey].Contains($polKey)) {
+            $policyIndex[$idKey][$polKey] = [PSCustomObject]@{
+                PolicyName   = $p.PolicyName
+                ActualValues = @()
+            }
+        }
+        $policyIndex[$idKey][$polKey].ActualValues += "$($p.ActualValue)"
+    }
+
+    # Aggregate baseline rows: baseline policy + setting id -> list of expected values.
+    $baselineIndex = [ordered]@{}
+    foreach ($b in $FlattenedBaseline) {
+        $id = "$($b.BaselineId)"
+        if (-not $id) {
+            Write-IntuneToolkitLog "Skipping baseline entry without setting ID for policy '$($b.BaselinePolicy)' ($($b.CompositeDescription))" -component "BaselineComparison" -file "Functions.ps1"
+            continue
+        }
+        $key = "$($b.BaselinePolicy)|$($id.ToLower())"
+        if (-not $baselineIndex.Contains($key)) {
+            $baselineIndex[$key] = [PSCustomObject]@{
+                BaselinePolicy       = $b.BaselinePolicy
+                CompositeDescription = $b.CompositeDescription
+                BaselineId           = $id
+                ExpectedValues       = @()
+            }
+        }
+        $baselineIndex[$key].ExpectedValues += "$($b.ExpectedValue)"
+    }
+
+    # Compare: per policy, the multiset of actual values must equal the multiset of expected values.
+    $separator = [string][char]31
+    $records = @()
+    foreach ($agg in $baselineIndex.Values) {
+        $policies = $policyIndex[$agg.BaselineId.ToLower()]
+        if (-not $policies -or $policies.Count -eq 0) {
+            $records += [PSCustomObject]@{
+                BaselinePolicy       = $agg.BaselinePolicy
+                CompositeDescription = $agg.CompositeDescription
+                BaselineId           = $agg.BaselineId
+                ExpectedValues       = $agg.ExpectedValues
+                PolicyMatches        = @()
+                Comparison           = "Missing"
+            }
+            continue
+        }
+        $expectedKey = (@($agg.ExpectedValues) | Sort-Object) -join $separator
+        $allMatch = $true
+        $policyMatches = @()
+        foreach ($pol in $policies.Values) {
+            $actualKey = (@($pol.ActualValues) | Sort-Object) -join $separator
+            if ($actualKey -ne $expectedKey) { $allMatch = $false }
+            $policyMatches += $pol
+        }
+        $records += [PSCustomObject]@{
+            BaselinePolicy       = $agg.BaselinePolicy
+            CompositeDescription = $agg.CompositeDescription
+            BaselineId           = $agg.BaselineId
+            ExpectedValues       = $agg.ExpectedValues
+            PolicyMatches        = $policyMatches
+            Comparison           = $(if ($allMatch) { "Matches" } else { "Differs" })
+        }
+    }
+    return $records
 }
 
 #endregion Flattening Functions

--- a/Scripts/SecurityBaselineAnalysisButton.ps1
+++ b/Scripts/SecurityBaselineAnalysisButton.ps1
@@ -73,9 +73,15 @@ $SecurityBaselineAnalysisButton.Add_Click({
         #--------------------------------------------------------------------------------
         # Block: Fetch and Merge Policy Settings via Graph API
         # Retrieve detailed configuration policy settings for each selected policy and merge them.
+        # The grid holds one row per assignment, so deduplicate by policy ID first: merging
+        # the same policy twice would inflate the value multisets and skew the comparison.
         #--------------------------------------------------------------------------------
+        $uniquePolicies = $PolicyDataGrid.SelectedItems |
+            Group-Object -Property { if ($_.PSObject.Properties["PolicyId"]) { $_.PolicyId } else { $_.id } } |
+            ForEach-Object { $_.Group[0] }
+        Write-IntuneToolkitLog "Unique selected policies count: $(@($uniquePolicies).Count)" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
         $mergedSettings = @()
-        foreach ($policy in $PolicyDataGrid.SelectedItems) {
+        foreach ($policy in $uniquePolicies) {
             try {
                 # Determine the policy ID (it could be stored as PolicyId or id).
                 $policyId = if ($policy.PSObject.Properties["PolicyId"]) { $policy.PolicyId } else { $policy.id }
@@ -173,8 +179,13 @@ $SecurityBaselineAnalysisButton.Add_Click({
         #--------------------------------------------------------------------------------
         # Block: Process Baseline Folders and Load JSON Baseline Policies
         # For each selected baseline folder, load and merge JSON baseline policies.
+        # Baseline policies are deduplicated by name across folders/files: bundled baselines
+        # ship the same policy in multiple folders (e.g. combined and per-level variants),
+        # and merging both copies would double the expected value multisets and report
+        # false "Differs" for every overlapping setting.
         #--------------------------------------------------------------------------------
         $mergedBaselineSettings = @()
+        $mergedBaselineNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         foreach ($folder in $selectedBaselineFolders) {
             try {
                 Write-IntuneToolkitLog "Attempting to read JSON files from baseline folder: $($folder.FullName)" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
@@ -234,10 +245,16 @@ $SecurityBaselineAnalysisButton.Add_Click({
                     if ($jsonContent.settings) {
                         $baselinePolicyName = $jsonContent.name
                         if (-not $baselinePolicyName) {
-                            Write-IntuneToolkitLog "No 'name' property found in $($file.FullName); using folder name $($folder.Name) as baseline policy name" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
-                            $baselinePolicyName = $folder.Name
+                            # Fall back to the file base name (matches the selection prompt); the folder
+                            # name would make multiple nameless files collide in the dedup below.
+                            Write-IntuneToolkitLog "No 'name' property found in $($file.FullName); using file name $($file.BaseName) as baseline policy name" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
+                            $baselinePolicyName = $file.BaseName
                         } else {
                             Write-IntuneToolkitLog "Extracted baseline policy name '$baselinePolicyName' from $($file.FullName)" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
+                        }
+                        if (-not $mergedBaselineNames.Add($baselinePolicyName)) {
+                            Write-IntuneToolkitLog "Skipping duplicate baseline policy '$baselinePolicyName' from $($file.FullName) (already merged from another file/folder)" -component "SecurityBaselineAnalysis-Button" -file "SecurityBaselineAnalysisButton.ps1"
+                            continue
                         }
                         foreach ($setting in $jsonContent.settings) {
                             $mergedBaselineSettings += [PSCustomObject]@{
@@ -307,19 +324,21 @@ $SecurityBaselineAnalysisButton.Add_Click({
 
         #--------------------------------------------------------------------------------
         # Block: Compare Baseline and Policy Settings
-        # Compare the flattened baseline settings (expected) against the flattened policy settings (actual)
-        # and build the comparison report.
+        # Compare the flattened baseline settings (expected) against the flattened policy
+        # settings (actual). Values are aggregated per setting ID and compared as multisets
+        # (see Build-BaselineComparison), so settings with multiple instances (e.g. group
+        # collections) compare correctly.
         #--------------------------------------------------------------------------------
-        $totalBaselineSettings = $flattenedBaseline.Count
-        $missingSettings = 0
-        $matchesCount = 0
-        $differsCount = 0
+        $comparisonRecords = @(Build-BaselineComparison -FlattenedBaseline $flattenedBaseline -FlattenedPolicy $flattenedPolicy)
+        $totalBaselineSettings = $comparisonRecords.Count
+        $missingSettings = @($comparisonRecords | Where-Object { $_.Comparison -eq "Missing" }).Count
+        $matchesCount = @($comparisonRecords | Where-Object { $_.Comparison -eq "Matches" }).Count
+        $differsCount = @($comparisonRecords | Where-Object { $_.Comparison -eq "Differs" }).Count
         $comparisonReport = @()
-        
-        foreach ($item in $flattenedBaseline) {
+
+        foreach ($item in $comparisonRecords) {
             $bp = $item.BaselinePolicy
             $baselineId = $item.BaselineId
-            $expectedValue = $item.ExpectedValue
 
             # Build display composite:
             if ($item.CompositeDescription -match "\\") {
@@ -330,42 +349,27 @@ $SecurityBaselineAnalysisButton.Add_Click({
             $displayDescription = Get-SettingDescription -settingId $baselineId -CatalogDictionary $CatalogDictionary
             # Remove newlines from description for clean display.
             $displayDescription = ($displayDescription -replace "[\r\n]+", " ").Trim()
-            # Look up the friendly expected value.
-            $expectedDisplay = Get-SettingDisplayValue -settingValueId $expectedValue -CatalogDictionary $CatalogDictionary
+            # Look up the friendly expected value(s).
+            $rawExpected = ($item.ExpectedValues -join "; ")
+            $expectedDisplay = ($item.ExpectedValues | ForEach-Object { Get-SettingDisplayValue -settingValueId $_ -CatalogDictionary $CatalogDictionary }) -join "; "
 
             # Use the Maybe-Shorten function to check for overly long or raw values.
             $displayComposite = Maybe-Shorten -raw $item.CompositeDescription -friendly $displayComposite
             $displayDescription = Maybe-Shorten -raw $baselineId -friendly $displayDescription
-            $expectedDisplay = Maybe-Shorten -raw $expectedValue -friendly $expectedDisplay
+            $expectedDisplay = Maybe-Shorten -raw $rawExpected -friendly $expectedDisplay
 
-            #Write-IntuneToolkitLog ("Catalog lookup for '$baselineId': Display='$displayComposite', Description='$displayDescription'") -component "CatalogLookup" -file "SecurityBaselineAnalysisButton.ps1"
-            #Write-IntuneToolkitLog ("Comparing baseline item: Policy='$bp', BaselineId='$baselineId', ExpectedValue='$expectedValue'") -component "Comparison" -file "SecurityBaselineAnalysisButton.ps1"
-
-            # Find matching policy settings based on the baseline setting ID.
-            $policyMatches = $flattenedPolicy | Where-Object { $_.PolicySettingId -eq $baselineId }
-            if (-not $policyMatches -or $policyMatches.Count -eq 0) {
+            if ($item.Comparison -eq "Missing") {
                 # If no match is found, add a report line indicating a missing policy.
                 $comparisonReport += "| $bp | $displayComposite | $displayDescription | $expectedDisplay | **Missing** | N/A | Missing |"
-                $missingSettings++
-                #Write-IntuneToolkitLog ("No matching policy settings found for BaselineId '$baselineId'") -component "Comparison" -file "SecurityBaselineAnalysisButton.ps1"
             } else {
                 # Concatenate the names of the policies that have a matching setting.
-                $policyList = ($policyMatches | ForEach-Object { "$($_.PolicyName)" }) -join "; "
-                # Look up the friendly display value for the actual values.
-                $actualValuesDisplay = ($policyMatches | ForEach-Object { Get-SettingDisplayValue -settingValueId $_.ActualValue -CatalogDictionary $CatalogDictionary }) -join "; "
-                $actualValuesDisplay = Maybe-Shorten -raw ($policyMatches | ForEach-Object { $_.ActualValue } | Out-String) -friendly $actualValuesDisplay
-                $allMatch = $true
-                # Check if every matched policy setting has the expected value.
-                foreach ($match in $policyMatches) {
-                    if ($match.ActualValue -ne $expectedValue) {
-                        $allMatch = $false
-                        break
-                    }
-                }
-                $comparison = if ($allMatch) { "Matches" } else { "Differs" }
-                $comparisonReport += "| $bp | $displayComposite | $displayDescription | $expectedDisplay | $policyList | $actualValuesDisplay | $comparison |"
-                #Write-IntuneToolkitLog ("Comparison for BaselineId '$baselineId': Expected='$expectedDisplay', PolicyList='$policyList', Actual='$actualValuesDisplay', Comparison='$comparison'") -component "Comparison" -file "SecurityBaselineAnalysisButton.ps1"
-                if ($allMatch) { $matchesCount++ } else { $differsCount++ }
+                $policyList = ($item.PolicyMatches | ForEach-Object { "$($_.PolicyName)" }) -join "; "
+                # Look up the friendly display value for the actual values (per policy).
+                $actualValuesDisplay = ($item.PolicyMatches | ForEach-Object {
+                    ($_.ActualValues | ForEach-Object { Get-SettingDisplayValue -settingValueId $_ -CatalogDictionary $CatalogDictionary }) -join "; "
+                }) -join "; "
+                $actualValuesDisplay = Maybe-Shorten -raw (($item.PolicyMatches | ForEach-Object { $_.ActualValues }) -join "; ") -friendly $actualValuesDisplay
+                $comparisonReport += "| $bp | $displayComposite | $displayDescription | $expectedDisplay | $policyList | $actualValuesDisplay | $($item.Comparison) |"
             }
         }
 
@@ -450,11 +454,11 @@ $SecurityBaselineAnalysisButton.Add_Click({
             # ------------------------------------
 
             # 1) Build two CSV tables: baseline comparison and extra policy settings
+            #    (reuses the aggregated comparison records so Markdown/CSV/HTML stay consistent)
             $baselineComparisonObjects = @()
-            foreach ($item in $flattenedBaseline) {
-                $bp               = $item.BaselinePolicy
-                $baselineId       = $item.BaselineId
-                $expectedValue    = $item.ExpectedValue
+            foreach ($item in $comparisonRecords) {
+                $bp         = $item.BaselinePolicy
+                $baselineId = $item.BaselineId
 
                 # Friendly lookups
                 if ($item.CompositeDescription -match "\\") {
@@ -463,7 +467,7 @@ $SecurityBaselineAnalysisButton.Add_Click({
                     $displayName = Get-SettingDisplayValue -settingValueId $baselineId -CatalogDictionary $CatalogDictionary
                 }
                 $description = Get-SettingDescription -settingId $baselineId -CatalogDictionary $CatalogDictionary
-                $expected    = Get-SettingDisplayValue -settingValueId $expectedValue -CatalogDictionary $CatalogDictionary
+                $expected    = ($item.ExpectedValues | ForEach-Object { Get-SettingDisplayValue -settingValueId $_ -CatalogDictionary $CatalogDictionary }) -join '; '
 
                      # Metadata (Platform/Technologies/Keywords) from catalog wrapper
                      $catalogEntry = Find-CatalogEntry -CatalogDictionary $CatalogDictionary -Key $baselineId
@@ -474,23 +478,15 @@ $SecurityBaselineAnalysisButton.Add_Click({
                                             } else { '' }
                      $keywordsMeta = if($catalogEntry -and $catalogEntry.Keywords){ $catalogEntry.Keywords } else { '' }
 
-                # Find policy matches (avoid using automatic variable $Matches)
-                $policyMatches = $flattenedPolicy | Where-Object { $_.PolicySettingId -eq $baselineId }
-                if (-not $policyMatches) {
-                    $status = 'Missing'
+                if ($item.Comparison -eq 'Missing') {
                     $policies = ''
                     $actual   = ''
                 } else {
-                    # Deduplicate by PolicyId + ActualValue to avoid duplicate value repeats within same policy
-                    $uniqueMatches = $policyMatches |
-                        Sort-Object -Property PolicyId, ActualValue -Unique
-                    # Make configured policy list unique & sorted (based on unique matches)
-                    $policies = ($uniqueMatches | ForEach-Object { $_.PolicyName } | Sort-Object -Unique) -join '; '
-                    $actual   = ($uniqueMatches | ForEach-Object {
-                        Get-SettingDisplayValue -settingValueId $_.ActualValue -CatalogDictionary $CatalogDictionary
+                    # Make configured policy list unique & sorted
+                    $policies = ($item.PolicyMatches | ForEach-Object { $_.PolicyName } | Sort-Object -Unique) -join '; '
+                    $actual   = ($item.PolicyMatches | ForEach-Object {
+                        ($_.ActualValues | ForEach-Object { Get-SettingDisplayValue -settingValueId $_ -CatalogDictionary $CatalogDictionary }) -join '; '
                     }) -join '; '
-                    $allMatch = $uniqueMatches | ForEach-Object { $_.ActualValue } | Where-Object { $_ -ne $expectedValue } | Measure-Object | Select-Object -ExpandProperty Count
-                    $status   = if ($allMatch -eq 0) { 'Matches' } else { 'Differs' }
                 }
 
                 $baselineComparisonObjects += [PSCustomObject]@{
@@ -503,7 +499,7 @@ $SecurityBaselineAnalysisButton.Add_Click({
                     ExpectedValue      = $expected
                     ConfiguredPolicies = $policies
                     ActualValues       = $actual
-                    Comparison         = $status
+                    Comparison         = $item.Comparison
                 }
             }
 

--- a/Scripts/SettingsReportButton.ps1
+++ b/Scripts/SettingsReportButton.ps1
@@ -85,7 +85,10 @@ $SettingsReportButton.Add_Click({
         foreach ($group in $grouped) {
             $id           = $group.Name
             if (-not $id) { continue }
-            $policiesList = ($group.Group | ForEach-Object { $_.PolicyName }) -join "; "
+            # A setting can legitimately produce several records within ONE policy (collection
+            # values, group instances), so "duplicate" means configured in more than one policy.
+            $distinctPolicies = @($group.Group | ForEach-Object { $_.PolicyName } | Sort-Object -Unique)
+            $policiesList = $distinctPolicies -join "; "
             $catalogEntry = Find-CatalogEntry -CatalogDictionary $CatalogDictionary -Key $id
             $dispName     = ((Get-SettingDisplayValue -settingValueId $id -CatalogDictionary $CatalogDictionary) | Where-Object { $_ })
             if (-not $dispName) { $dispName = $id }
@@ -118,7 +121,7 @@ $SettingsReportButton.Add_Click({
                 Setting          = $dispName
                 Description      = $desc
                 ConfiguredValue  = $valueDisplay
-                Duplicates       = [bool]($group.Count -gt 1)
+                Duplicates       = [bool]($distinctPolicies.Count -gt 1)
                 Platform         = $platformNorm
                 KeywordsRaw      = $keywords
                 PolicySettingId  = $id
@@ -140,10 +143,10 @@ $SettingsReportButton.Add_Click({
                     $dlg.Title    = 'Save Settings Report'
                     $dlg.FileName = "$baseName.md"
                     if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
-                        # Overview of shared settings
-                        $overview = foreach ($g in $grouped | Where-Object { $_.Count -gt 1 }) {
+                        # Overview of shared settings (shared = configured in more than one policy)
+                        $overview = foreach ($g in $grouped | Where-Object { @($_.Group | ForEach-Object { $_.PolicyName } | Sort-Object -Unique).Count -gt 1 }) {
                             $name = (Get-SettingDisplayValue -settingValueId $g.Name -CatalogDictionary $CatalogDictionary) || $g.Name
-                            $pols = ($g.Group | ForEach-Object { $_.PolicyName }) -join "; "
+                            $pols = ($g.Group | ForEach-Object { $_.PolicyName } | Sort-Object -Unique) -join "; "
                             "- **$name** configured in policies: $pols"
                         }
                         $md = @('# Settings Report', '', '## Overview: Shared Settings', '')


### PR DESCRIPTION
## Problem

When a Settings Catalog setting is set to **Enabled** and exposes sub-settings, those sub-settings were not compared or shown in any report. Choice settings carry their children in `choiceSettingValue.children`, which `Flatten-BaselineSettings` / `Flatten-PolicySettings` never traversed — across the bundled baselines alone, **1,386 child settings were silently dropped** from the Security Baseline Analysis (Markdown/CSV/HTML) and the Settings Report. Collection-type settings (`simpleSettingCollectionInstance`, `choiceSettingCollectionInstance`) and nested groups were also unhandled and reported as `Not Defined`.

## What changed

### `Scripts/Functions.ps1`
- **New recursive `Flatten-SettingInstance`** replaces the one-level flatteners. It handles every Graph instance shape: choice (+ children at any depth), choice collection, simple, simple collection (one record per value, so ordering does not matter), group collection (children of every instance) and singular group instances. Composite paths chain as `Parent\Child\...` and keep working with the existing friendly-name lookups.
- **Integer `0` values are kept** — previously a falsy-value check turned them into `Not Defined`.
- **Per-instance fingerprints for group collections**: each group instance emits a canonical record of its child values, so swapping values *between* instances (e.g. threat-type → action mappings) is still reported as `Differs` even though values are aggregated per setting ID.
- **New `Build-BaselineComparison`**: aggregates expected/actual values per setting ID and compares them as **multisets per policy**. The old per-row equality produced false `Differs` for every multi-instance setting — a baseline compared against itself did not score 100%. It does now. The comparison is intentionally count-sensitive: more instances than the baseline (even with identical values) reports `Differs`.
- `Flatten-PolicySettings` now passes `PolicyId` through, making the existing CSV dedup (`Sort-Object PolicyId, ActualValue -Unique`) actually work.
- Fixed `Maybe-Shorten` ($friendly typo, XML detection that could never match, operator precedence).

### `Scripts/SecurityBaselineAnalysisButton.ps1`
- **Deduplicate selected grid rows by policy ID** — the grid holds one row per assignment, so selecting a multi-assignment policy merged its settings twice and skewed the comparison.
- **Deduplicate baseline policies by name across folders/files** — bundled content ships the same policy in multiple folders (OIB v3.5/v3.6, macOS combined/per-level); merging both copies doubled the expected values and flagged fully compliant tenants as `Differs`.
- Markdown, CSV and HTML outputs are now all built from the same comparison records instead of three divergent computations.

### `Scripts/SettingsReportButton.ps1`
- A setting is flagged **Duplicate only when configured in more than one policy** — collection values and group instances within a single policy no longer trigger the flag, repeat policy names, or inflate the duplicates summary.

## Verification

- 4,036-assertion headless harness over all 172 bundled baseline JSONs:
  - full parity with the previous flattener on everything it handled correctly,
  - all 1,386 choice children now surfaced,
  - **baseline-vs-itself comparison: 4,329/4,329 Matches, 0 Differs, 0 Missing, 0 Extra** with both PSCustomObject (baseline JSON) and hashtable (`Invoke-MgGraphRequest`) inputs,
  - edge cases: grandchildren, nested groups, swapped/reordered instances, reordered collections, integer 0, fingerprint separator collisions, empty groups, missing settingInstance.
- Two multi-agent adversarial review passes over the diff; all confirmed findings addressed (input dedup, cross-instance pairing, duplicate-flag semantics) or documented as intended strictness.

## Notes

- Summary counts now count **settings** (aggregated per ID) instead of flattened rows, so totals differ from previous reports by design.
- Group-container rows display a technical `child=value | child=value` fingerprint in the value columns; the friendly per-child rows appear directly beneath them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)