### PR TITLE
Add filter to show items with no assignments

### DIFF
--- a/Invoke-IntuneToolkit.ps1
+++ b/Invoke-IntuneToolkit.ps1
@@ -142,6 +142,7 @@ function Show-Window {
         $SearchBox = $Window.FindName("SearchBox")
         $SearchButton = $Window.FindName("SearchButton")
         $SearchFieldComboBox = $Window.FindName("SearchFieldComboBox")
+        $ShowUnassignedButton = $Window.FindName("ShowUnassignedButton")
         $SecurityBaselineAnalysisButton = $Window.FindName("SecurityBaselineAnalysisButton")
         $SettingsReportButton = $Window.FindName("SettingsReportButton")
         $DeviceCustomAttributeShellScriptsButton = $Window.FindName("DeviceCustomAttributeShellScriptsButton")
@@ -278,6 +279,7 @@ function Show-Window {
         . .\Scripts\DeletePolicyButton.ps1  # New Delete Policy script
         . .\Scripts\Show-SelectionDialog.ps1
         . .\Scripts\SearchButton.ps1
+        . .\Scripts\ShowUnassignedButton.ps1
         . .\Scripts\GlobalGroupSearchButton.ps1
         . .\Scripts\Show-GroupSearchDialog.ps1
         . .\Scripts\RemediationScriptsButton.ps1

--- a/Scripts/Functions.ps1
+++ b/Scripts/Functions.ps1
@@ -606,6 +606,7 @@ function Load-PolicyData {
     $SearchFieldComboBox.IsEnabled = $false
     $SearchBox.IsEnabled = $false
     $SearchButton.IsEnabled = $false
+    $ShowUnassignedButton.IsEnabled = $false
     $AssignmentReportButton.IsEnabled = $false
     $RefreshButton.IsEnabled = $false
     $RenameButton.IsEnabled = $false
@@ -619,6 +620,8 @@ function Load-PolicyData {
     # Update the DataGrid with the loaded data.
     $PolicyDataGrid.ItemsSource = @($result)
     $PolicyDataGrid.Items.Refresh()
+    # Reset the "Show Unassigned" toggle so it matches the freshly loaded (unfiltered) data.
+    if ($ShowUnassignedButton) { $ShowUnassignedButton.IsChecked = $false }
 
     # Determine which columns should be visible based on the policy type.
     $InstallIntentColumn = $PolicyDataGrid.Columns | Where-Object { $_.Header -eq "Install Intent" }
@@ -698,6 +701,7 @@ function Load-PolicyData {
     $SearchFieldComboBox.IsEnabled = $true
     $SearchBox.IsEnabled = $true
     $SearchButton.IsEnabled = $true
+    $ShowUnassignedButton.IsEnabled = $true
     $AssignmentReportButton.IsEnabled = $true
     $RefreshButton.IsEnabled = $true
     $RenameButton.IsEnabled = $true

--- a/Scripts/ShowUnassignedButton.ps1
+++ b/Scripts/ShowUnassignedButton.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+Handles the ShowUnassignedButton toggle to show only items that have no assignments.
+
+.DESCRIPTION
+This script wires the "Show Unassigned" toggle button. When checked, the PolicyDataGrid is
+filtered to the items in $global:AllPolicyData that have no assignment (an empty
+GroupDisplayname), which is how unassigned policies/applications are represented after loading
+(see Load-PolicyData / Process-Assignment in Functions.ps1). When unchecked, the full, unfiltered
+list is restored. This makes it easy to find, for example, applications that are not assigned to
+any group. Requested in issue #63.
+
+.NOTES
+Author: Intune Toolkit contributors
+Date: 2026-07-24
+
+.EXAMPLE
+$ShowUnassignedButton.Add_Checked({
+    # Code to handle toggle
+})
+#>
+
+# Show only items with no assignment (empty GroupDisplayname).
+$ShowUnassignedButton.Add_Checked({
+    try {
+        Write-IntuneToolkitLog "ShowUnassignedButton checked" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+
+        if (-not $global:AllPolicyData) {
+            Write-IntuneToolkitLog "No policy data loaded; nothing to filter" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+            return
+        }
+
+        $unassigned = @($global:AllPolicyData | Where-Object { [string]::IsNullOrWhiteSpace($_.GroupDisplayname) })
+        $PolicyDataGrid.ItemsSource = $unassigned
+        $PolicyDataGrid.Items.Refresh()
+
+        Write-IntuneToolkitLog "Showing $($unassigned.Count) item(s) with no assignment" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+    } catch {
+        $errorMessage = "Failed to show unassigned items. Error: $($_.Exception.Message)"
+        Write-Error $errorMessage
+        Write-IntuneToolkitLog $errorMessage -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+    }
+})
+
+# Restore the full, unfiltered list.
+$ShowUnassignedButton.Add_Unchecked({
+    try {
+        Write-IntuneToolkitLog "ShowUnassignedButton unchecked" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+
+        $PolicyDataGrid.ItemsSource = @($global:AllPolicyData)
+        $PolicyDataGrid.Items.Refresh()
+
+        Write-IntuneToolkitLog "Restored full policy list" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+    } catch {
+        $errorMessage = "Failed to restore full list. Error: $($_.Exception.Message)"
+        Write-Error $errorMessage
+        Write-IntuneToolkitLog $errorMessage -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
+    }
+})

--- a/Scripts/ShowUnassignedButton.ps1
+++ b/Scripts/ShowUnassignedButton.ps1
@@ -25,12 +25,17 @@ $ShowUnassignedButton.Add_Checked({
     try {
         Write-IntuneToolkitLog "ShowUnassignedButton checked" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
 
-        if (-not $global:AllPolicyData) {
+        if ($null -eq $global:AllPolicyData) {
             Write-IntuneToolkitLog "No policy data loaded; nothing to filter" -component "ShowUnassigned-Button" -file "ShowUnassignedButton.ps1"
             return
         }
 
-        $unassigned = @($global:AllPolicyData | Where-Object { [string]::IsNullOrWhiteSpace($_.GroupDisplayname) })
+        $unassigned = @(
+            $global:AllPolicyData | Where-Object {
+                ([string]::IsNullOrWhiteSpace($_.AssignmentType) -or $_.AssignmentType -eq "Not Assigned") -and
+                [string]::IsNullOrWhiteSpace($_.GroupDisplayname)
+            }
+        )
         $PolicyDataGrid.ItemsSource = $unassigned
         $PolicyDataGrid.Items.Refresh()
 

--- a/XML/Main.xaml
+++ b/XML/Main.xaml
@@ -246,6 +246,7 @@
     <StackPanel Orientation="Horizontal" Grid.Row="3" Margin="10,0,10,0">
         <Button x:Name="AddFilterButton" Content="+" Width="30" Style="{StaticResource BaseButtonStyle}" IsEnabled="False" Margin="0,0,2,0"/>
         <Button x:Name="SearchButton" Content="Search" Width="80" Style="{StaticResource BaseButtonStyle}" IsEnabled="False"/>
+        <ToggleButton x:Name="ShowUnassignedButton" Content="Show Unassigned" Width="140" Style="{StaticResource SidebarToggleStyle}" IsEnabled="False" Margin="10,0,0,0" ToolTip="Show only items that have no assignments"/>
     </StackPanel>
         </Grid>
         <TextBlock x:Name="StatusText" Text="Please login to Graph before using the app" HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Row="2" Grid.Column="1"/>


### PR DESCRIPTION
Add a "Show Unassigned" toggle next to the search controls. When enabled it filters the grid to items whose GroupDisplayname is empty, which is how a policy or application with no assignments is represented after loading. This makes it easy to spot, for example, applications that are not assigned to any group, without scrolling through the full list.

The toggle is enabled once policy data is loaded, resets when a new policy type is loaded, and restores the full list when switched off.

Closes #63