### PR TITLE
Flatten line feeds in CSV export

### DIFF
--- a/Scripts/AssignmentReportButton.ps1
+++ b/Scripts/AssignmentReportButton.ps1
@@ -143,7 +143,19 @@ function Export-ToCsv {
         [PSObject]$PolicyItems
     )
     try {
-        $PolicyItems | Export-Csv -Path $OutputPath -NoTypeInformation
+        # Flatten line feeds in the description so each item stays on a single CSV line.
+        # Embedded CR/LF in PolicyDescription otherwise break rows when the CSV is pasted
+        # into Excel (see issue #56). Copies are used so the in-memory grid data (shared
+        # with $global:AllPolicyData and the other exporters) is left untouched.
+        $exportItems = $PolicyItems | ForEach-Object {
+            $item = $_.PSObject.Copy()
+            if ($null -ne $item.PolicyDescription) {
+                $item.PolicyDescription = [string]$item.PolicyDescription -replace '\r\n|\r|\n', ' '
+            }
+            $item
+        }
+
+        $exportItems | Export-Csv -Path $OutputPath -NoTypeInformation
         [System.Windows.MessageBox]::Show('CSV export succeeded','Success',[System.Windows.MessageBoxButton]::OK,[System.Windows.MessageBoxImage]::Information)
     } catch {
         [System.Windows.MessageBox]::Show("CSV export failed: $_","Error",[System.Windows.MessageBoxButton]::OK,[System.Windows.MessageBoxImage]::Error)

--- a/Scripts/AssignmentReportButton.ps1
+++ b/Scripts/AssignmentReportButton.ps1
@@ -144,7 +144,7 @@ function Export-ToCsv {
     )
     try {
         # Flatten line feeds in the description so each item stays on a single CSV line.
-        # Embedded CR/LF in PolicyDescription otherwise break rows when the CSV is pasted
+        # Embedded CR/LF in PolicyDescription otherwise breaks rows when the CSV is pasted
         # into Excel (see issue #56). Copies are used so the in-memory grid data (shared
         # with $global:AllPolicyData and the other exporters) is left untouched.
         $exportItems = $PolicyItems | ForEach-Object {


### PR DESCRIPTION
CR/LF characters in PolicyDescription were written verbatim into the CSV, so a single item spanned several physical lines and broke row alignment when the file was pasted into Excel. Export-ToCsv now replaces CR/LF with spaces on per-item copies, keeping each record on one line while leaving the in-memory grid data (and the Markdown/HTML exporters) untouched.

Fixes #56