### PR TITLE
Print one policy per line in the Settings Report (Fixes #54)

### DIFF
--- a/Scripts/SettingsReportButton.ps1
+++ b/Scripts/SettingsReportButton.ps1
@@ -153,7 +153,8 @@ $SettingsReportButton.Add_Click({
                         if ($overview) { $md += $overview } else { $md += '- No settings shared across multiple policies.' }
                         $md += @('', '| Policy Name | Setting | Description | Value |', '|-------------|---------|-------------|-------|')
                         foreach ($r in $reportItems) {
-                            $md += "| $($r.PolicyName) | $($r.Setting) | $($r.Description) | $($r.ConfiguredValue) |"
+                            # Issue #54: render each policy / value on its own line inside the cell.
+                            $md += "| $($r.PolicyName -replace '; ','<br>') | $($r.Setting) | $($r.Description) | $($r.ConfiguredValue -replace '; ','<br>') |"
                         }
                         $md -join "`r`n" | Out-File -FilePath $dlg.FileName -Encoding UTF8
                     }
@@ -196,11 +197,11 @@ $SettingsReportButton.Add_Click({
                                                                                                 $uniqPct = _pct $uniqueCount $totalSettings
 
                                                                                                 $rowsHtml = foreach($r in $reportItems){
-                                                                                                        $policyEsc  = [System.Web.HttpUtility]::HtmlEncode($r.PolicyName)
+                                                                                                        $policyEsc  = (($r.PolicyName -split '; ') | ForEach-Object { [System.Web.HttpUtility]::HtmlEncode($_) }) -join '<br>'  # issue #54: split then encode so one policy per line (keeps &amp; intact)
                                                                                                         $settingEsc = [System.Web.HttpUtility]::HtmlEncode($r.Setting)
                                                                                                         $descRaw    = if($r.Description){ $r.Description } else { '' }
                                                                                                         $descEsc    = [System.Web.HttpUtility]::HtmlEncode(($descRaw -replace "`r?`n"," "))
-                                                                                                        $valEsc     = [System.Web.HttpUtility]::HtmlEncode($r.ConfiguredValue)
+                                                                                                        $valEsc     = (($r.ConfiguredValue -split '; ') | ForEach-Object { [System.Web.HttpUtility]::HtmlEncode($_) }) -join '<br>'  # issue #54: one configured value per line
                                                                                                         $platEsc    = [System.Web.HttpUtility]::HtmlEncode($r.Platform)
                                                                                                         $tagsHtml   = ''
                                                                                                         $dataTags   = ''


### PR DESCRIPTION
# Print one policy per line in the Settings Report (Fixes #54)

## Problem
In the **Settings Report** export, when a setting is configured by more than one policy, the
"Policy Name(s)" column (and likewise the "Configured Value" column) is rendered as a single
`"; "`-joined line. For settings shared across several policies this becomes one long, hard-to-read
line. Reported in #54 with a screenshot (the `AV - Tamper Internal; AV - Tamper Demo; …` cell and
the `On; Off` value cell).

## Fix
`Scripts/SettingsReportButton.ps1` builds the `Policy Name(s)` and `Configured Value` values by
joining with `"; "`. This change breaks those two cells onto one item per line in both the **HTML**
and **Markdown** exports:

- **HTML:** split the joined string on `"; "`, HTML-encode each part, then join with `<br>`.
  Splitting *before* encoding matters — encoding first would turn `&` into `&amp;` and the
  line-break replacement could then break inside that entity (e.g. `Security & Compliance` →
  `Security &amp<br>Compliance`). Splitting first avoids that.
- **Markdown:** replace `"; "` with `<br>` in the two cells (GitHub-flavoured Markdown renders
  `<br>` inside table cells).
- **CSV:** unchanged — it already uses `;` as the field delimiter, and one-item-per-line there would
  mean embedded newlines.
