### PR TITLE
Edit an existing assignment instead of delete-then-re-add (Fixes #57)

### DIFF
--- a/Scripts/AddAssignmentButton.ps1
+++ b/Scripts/AddAssignmentButton.ps1
@@ -22,6 +22,37 @@ $AddAssignmentButton.Add_Click({
 })
 #>
 
+#--------------------------------------------------------------------------------
+# Helper: Test-SameAssignmentTarget
+# Returns $true when an existing Graph assignment targets the same audience as the
+# assignment the user is adding. Used so that re-adding an already-assigned target
+# (for example, to add an include filter to an existing "All Devices" assignment)
+# updates that assignment instead of being silently ignored by Graph as a duplicate
+# target (issue #57).
+#
+# "All Users" / "All Devices" are virtual targets with no groupId, so they are matched
+# on their @odata.type alone; group include/exclude targets are matched on both the
+# @odata.type and the groupId.
+#--------------------------------------------------------------------------------
+function Test-SameAssignmentTarget {
+    param (
+        [Parameter(Mandatory = $true)] $ExistingTarget,
+        [Parameter(Mandatory = $true)] $NewTarget
+    )
+
+    $existingType = [string]$ExistingTarget.'@odata.type'
+    $newType      = [string]$NewTarget.'@odata.type'
+    if ($existingType -ne $newType) { return $false }
+
+    if ($existingType -eq "#microsoft.graph.groupAssignmentTarget" -or
+        $existingType -eq "#microsoft.graph.exclusionGroupAssignmentTarget") {
+        return ([string]$ExistingTarget.groupId -eq [string]$NewTarget.groupId)
+    }
+
+    # All Users / All Devices (and any other group-less target) match on type alone.
+    return $true
+}
+
 $AddAssignmentButton.Add_Click({
     # Log the button click event.
     Write-IntuneToolkitLog "AddAssignmentButton clicked" -component "AddAssignment-Button" -file "AddAssignmentButton.ps1"
@@ -239,6 +270,14 @@ $AddAssignmentButton.Add_Click({
                 # Build the target object with the proper OData type.
                 $target = @{ '@odata.type' = $targetType }
                 if ($groupId) { $target.groupId = $groupId }
+
+                # Issue #57: if this policy already has an assignment for the same target,
+                # drop the existing one so the new selection (which may add or change a
+                # filter / intent) replaces it, instead of being ignored by Graph as a
+                # duplicate target. This is what lets an assignment be "edited" (e.g. adding
+                # an include filter to an existing All Devices assignment) without having to
+                # delete and re-create it.
+                $currentAssignments = @($currentAssignments | Where-Object { -not (Test-SameAssignmentTarget -ExistingTarget $_.target -NewTarget $target) })
 
                 # Build the new assignment based on the policy type.
                 if ($global:CurrentPolicyType -eq "mobileApps") {


### PR DESCRIPTION
# Edit an existing assignment instead of delete-then-re-add (Fixes #57)

> ⚠️ **Needs dev-tenant validation before submitting.** This changes a Graph *mutating* path
> (`/assign`). The target-matching logic is unit-tested, but the end-to-end Graph result should be
> confirmed in a test tenant first (see Testing).

## Problem (root cause)
`AddAssignmentButton.ps1` fetches the policy's current assignments, **appends** the new assignment,
and re-POSTs the whole set to `/assign`. When the selected target is already assigned (e.g. an app
already assigned to **All Devices**), the set then contains two assignments for the same target.
Graph ignores the duplicate, so a newly added include filter never takes effect, and the user has to
delete the assignment and re-create it (issue #57).

## Fix
Before appending the new assignment, drop any existing assignment that targets the **same audience**,
so the new selection *replaces* it. A small helper `Test-SameAssignmentTarget` matches:

- `All Users` / `All Devices`: virtual targets with no `groupId`, matched on `@odata.type` alone.
- group include / exclude: matched on `@odata.type` **and** `groupId`.

Net effect: re-adding an already-assigned target now **updates** it (adds/changes the filter, intent,
or settings) instead of being ignored, which is the "edit assignment" behaviour requested.

Autopilot profiles are unaffected (they POST individual assignments and don't go through this set).



## Testing
- **Unit-tested** `Test-SameAssignmentTarget` (function extracted via AST): All Devices vs All Devices
  (match), All Devices vs All Users (no match), group g1 vs g1 (match), g1 vs g2 (no match), include g1
  vs exclude g1 (no match).
- **End-to-end (simulated):** existing `[All Devices no-filter] + [Group g1]`, adding
  `All Devices + filter` gives `[Group g1] + [All Devices WITH filter]` (the filterless one is
  replaced).
- Parses with no new errors; no BOM/encoding changes.
- **Not yet validated against a live tenant.** Recommended before merge: pick an app already assigned
  to All Devices, use Add Assignment on All Devices with an include filter, save, and confirm the
  filter now shows (and no duplicate/again-ignored behaviour).
